### PR TITLE
Fix: streaming message display in LLM chatbot

### DIFF
--- a/src/react_agent/app.py
+++ b/src/react_agent/app.py
@@ -556,7 +556,7 @@ def AssistantMessagePlaceholder(thread_id: str, run_id: str) -> Div:
         sse_connect=f"/conversations/{thread_id}/get-message?run_id={run_id}",
         sse_swap="message",
         hx_target=f"#{content_id}",
-        hx_swap="innerHTML",
+        hx_swap="beforeend",
     )
 
 


### PR DESCRIPTION
### Description

This PR changes the hx_swap attribute from innerHTML to beforeend in the AssistantMessagePlaceholder function to correctly handle streaming responses from the LLM. This fixes the issue where only the last streaming chunk was being displayed instead of the complete response.

### Changes

Changed hx_swap="innerHTML" to hx_swap="beforeend" in the AssistantMessagePlaceholder function
This modification allows new message chunks to be appended to existing content rather than replacing it
Maintains the complete message history during streaming

ref. https://htmx.org/attributes/hx-swap/