### PR TITLE
ci: add least-privilege permissions to workflow files

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,9 @@ on:
     - cron: "37 14 * * *" # Run at 7:37 AM Pacific Time (14:37 UTC) every day
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another scheduled run starts while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 concurrency:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 concurrency:


### PR DESCRIPTION
## Summary
- Adds top-level `permissions: contents: read` to `unit-tests.yml` and `integration-tests.yml`
- Resolves code scanning alerts [#1](https://github.com/langchain-ai/langgraph-fullstack-python/security/code-scanning/1) and [#2](https://github.com/langchain-ai/langgraph-fullstack-python/security/code-scanning/2) for `actions/missing-workflow-permissions`
- Both workflows only check out code and run tests, so read-only contents permission is sufficient

## Test plan
- [ ] Verify unit-tests workflow still passes on this PR
- [ ] Verify integration-tests workflow can be triggered manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)